### PR TITLE
fix:Add the search bar to docs layout header

### DIFF
--- a/app/docs/layout.tsx
+++ b/app/docs/layout.tsx
@@ -7,6 +7,7 @@ import { useState } from "react"
 import { ListIcon, XIcon } from "@phosphor-icons/react"
 import { Logo } from "@/components/logo"
 import { ColorThemePicker } from "@/components/home/color-theme-picker"
+import { CommandSearch } from "@/components/command-search"
 
 const sidebarItems = [
     {
@@ -109,12 +110,15 @@ export default function DocsLayout({
                 <Link href="/">
                     <Logo />
                 </Link>
+                <div className="flex items-center gap-10">
+                <CommandSearch />
                 <button
                     onClick={() => setIsSidebarOpen(!isSidebarOpen)}
                     className="p-2 focus-brutal cursor-pointer"
                 >
                     {isSidebarOpen ? <XIcon size={28} weight="bold" /> : <ListIcon size={28} weight="bold" />}
                 </button>
+                </div>
             </div>
 
             {isSidebarOpen && (


### PR DESCRIPTION
Fixes #15
THE ISSUE #12 SHOULD BE MERGED FIRST WHICH POINTS TO PR #28, OTHERWISE THERE WOULD BE MERGE CONFLICT OR IT MIGHT NOT WORK AS IT SUPPOSED TO BE.
Used the <CommandSearch.  /> to searching functionality in docs layout header.