### PR TITLE
fix:FUNDING.yml has invalid or unsupported entries

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,15 +1,11 @@
-# These are supported funding model platforms
+github:
+  - Bridgetamana
 
-github: [Bridgetamana]
-patreon: # Replace with a single Patreon username
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
-polar: # Replace with a single Polar username
-buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
-thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+# patreon: yourPatreonUsername
+# open_collective: yourOpenCollective
+# ko_fi: yourKofi
+# buy_me_a_coffee: yourBuyMeACoffee
+# liberapay: yourLiberapay
+# tidelift: npm/your-package
+# custom:
+#   - https://your-site.com/sponsor


### PR DESCRIPTION
Fixes #33
As empty keys are not allowed,Even with comments, GitHub still parses the key and fails validation if the value is empty.
So, it's better to comment them out rather than keeping them empty