### PR TITLE
feat:Add "Become a Sponsor" section to landing page footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,11 @@
-"use client"
+"use client";
 
-import { SiteHeader } from "@/components/site-header"
-import { SiteFooter } from "@/components/site-footer"
-import { HeroSection } from "@/components/home/hero"
-import { StatsSection } from "@/components/home/stats"
-import { ColorThemePicker } from "@/components/home/color-theme-picker"
+import { SiteHeader } from "@/components/site-header";
+import { SiteFooter } from "@/components/site-footer";
+import { HeroSection } from "@/components/home/hero";
+import { StatsSection } from "@/components/home/stats";
+import { ColorThemePicker } from "@/components/home/color-theme-picker";
+import { Sponsor } from "@/components/Sponsor";
 
 export default function Home() {
   return (
@@ -16,6 +17,7 @@ export default function Home() {
         <SiteFooter />
       </main>
       <ColorThemePicker />
+      <Sponsor />
     </div>
-  )
+  );
 }

--- a/components/Sponsor.tsx
+++ b/components/Sponsor.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import Link from "next/link";
+
+export const Sponsor = () => {
+  return (
+    <div className="border rounded-lg p-6">
+      <h2 className="text-xl font-semibold">Become a Sponsor</h2>
+      <p className="mt-2 text-sm">
+        Support the development and long-term maintenance of this project.
+      </p>
+
+      <Link
+        href="https://github.com/sponsors/Bridgetamana"
+        target="_blank"
+        rel="github sponsor"
+        className="inline-block mt-4 rounded-md bg-black px-5 py-2 text-white"
+      >
+        Sponsor on GitHub
+      </Link>
+    </div>
+  );
+};


### PR DESCRIPTION
Fixes #18
Currently the "Become a Sponsor" section is added to the website, previously because of the FUNDING.YML the sponsor button was visible only to Github page and there was no way it could reflect on the website so the Sponsor.tsx is added to reflect the changes on the website but the readme can't be updated now as it could create a merge conflict due to issue number #19 which points to PR #32 